### PR TITLE
Develop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdfwf"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     {name = "Kyle Hippe", email = "khippe@anl.gov"},
     {name = "Alexander Brace", email = "abrace@anl.gov"},


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->
This bug fix addresses an error in the warmstart parser registration. The factory function which is used to construct the parser object (whose outputs are cached in the registry) cannot be a closure since each time a new Parsl task starts, the call to the factory produces a new closure. Instead, we move the parser factory to the module namespace so that subsequent calls are properly cached.

This change fixes the output jsonl file per chunk bug that was observed and also improves efficiency by properly enabling warmstarts.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #10

### Type of Change
<!--- Check which off the following types describe this PR --->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [X] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [X] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [X] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [ ] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
