### PR TITLE
Adding checkpointing for .zip file parsing

### DIFF
--- a/examples/convert_markdown_to_jsonl.py
+++ b/examples/convert_markdown_to_jsonl.py
@@ -1,4 +1,5 @@
 """Converts a directory of markdown files to JSONL files."""
+
 from __future__ import annotations
 
 import json

--- a/examples/convert_parquet_to_jsonl.py
+++ b/examples/convert_parquet_to_jsonl.py
@@ -1,4 +1,5 @@
 """Converts a directory of markdown files to JSONL files."""
+
 from __future__ import annotations
 
 import json

--- a/examples/oreo/polaris-scaling/ian-imports2.oreo.yaml
+++ b/examples/oreo/polaris-scaling/ian-imports2.oreo.yaml
@@ -62,4 +62,3 @@ compute_settings:
   queue: R1800955
   # The amount of time to request for your job
   walltime: "24:00:00"
-

--- a/examples/oreo/polaris-scaling/oreo.polaris.nodes128.yaml
+++ b/examples/oreo/polaris-scaling/oreo.polaris.nodes128.yaml
@@ -65,4 +65,3 @@ compute_settings:
   queue: run_next
   # The amount of time to request for your job
   walltime: "1:00:00"
-

--- a/examples/oreo/polaris-scaling/oreo.polaris.nodes2.yaml
+++ b/examples/oreo/polaris-scaling/oreo.polaris.nodes2.yaml
@@ -65,4 +65,3 @@ compute_settings:
   queue: demand
   # The amount of time to request for your job
   walltime: "1:00:00"
-

--- a/examples/oreo/polaris-scaling/oreo.polaris.nodes256.yaml
+++ b/examples/oreo/polaris-scaling/oreo.polaris.nodes256.yaml
@@ -65,4 +65,3 @@ compute_settings:
   queue: run_next
   # The amount of time to request for your job
   walltime: "1:00:00"
-

--- a/examples/oreo/polaris-scaling/oreo.polaris.nodes32.yaml
+++ b/examples/oreo/polaris-scaling/oreo.polaris.nodes32.yaml
@@ -65,4 +65,3 @@ compute_settings:
   queue: demand
   # The amount of time to request for your job
   walltime: "1:00:00"
-

--- a/examples/oreo/polaris-scaling/oreo.polaris.nodes450.yaml
+++ b/examples/oreo/polaris-scaling/oreo.polaris.nodes450.yaml
@@ -65,4 +65,3 @@ compute_settings:
   queue: run_next
   # The amount of time to request for your job
   walltime: "1:00:00"
-

--- a/examples/oreo/polaris-scaling/oreo.polaris.nodes64.yaml
+++ b/examples/oreo/polaris-scaling/oreo.polaris.nodes64.yaml
@@ -65,4 +65,3 @@ compute_settings:
   queue: run_next
   # The amount of time to request for your job
   walltime: "1:00:00"
-

--- a/pdfwf/__init__.py
+++ b/pdfwf/__init__.py
@@ -1,4 +1,5 @@
 """pdfwf package."""
+
 from __future__ import annotations
 
 import importlib.metadata as importlib_metadata

--- a/pdfwf/balance.py
+++ b/pdfwf/balance.py
@@ -1,4 +1,5 @@
 """Balance output jsonl files from a workflow run."""
+
 from __future__ import annotations
 
 import functools

--- a/pdfwf/cli.py
+++ b/pdfwf/cli.py
@@ -1,4 +1,5 @@
 """CLI for the PDF workflow package."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/pdfwf/convert.py
+++ b/pdfwf/convert.py
@@ -71,6 +71,9 @@ def parse_pdfs(
         with open(output_dir / f'{parser.unique_id}.jsonl', 'a+') as f:
             f.write(lines)
 
+    # Sometimes parsl won't flush the stdout, so this is necessary for logs
+    print('', end='', flush=True)
+
 
 def parse_zip(
     zip_file: str,
@@ -137,6 +140,8 @@ def parse_zip(
     finally:
         # Stop the timer to log the worker time
         timer.stop()
+        # Sometimes parsl won't flush the stdout, so this is necessary for logs
+        print('', end='', flush=True)
 
 
 def parse_checkpoint(checkpoint_path: str) -> set[str]:

--- a/pdfwf/parsers/__init__.py
+++ b/pdfwf/parsers/__init__.py
@@ -1,4 +1,5 @@
 """The parsers module storing different PDF parsers."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/pdfwf/parsers/marker.py
+++ b/pdfwf/parsers/marker.py
@@ -1,4 +1,5 @@
 """The marker PDF parser."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/pdfwf/parsers/nougat_.py
+++ b/pdfwf/parsers/nougat_.py
@@ -83,7 +83,7 @@ class NougatParser(BaseParser):
     def __init__(self, config: NougatParserConfig) -> None:
         """Initialize the marker parser."""
         import torch
-        from nougat import NougatModel  # type: ignore
+        from nougat import NougatModel
         from nougat.utils.device import move_to_device
 
         self.config = config

--- a/pdfwf/parsers/nougat_.py
+++ b/pdfwf/parsers/nougat_.py
@@ -1,4 +1,5 @@
 """The Nougat PDF parser."""
+
 from __future__ import annotations
 
 import re
@@ -82,7 +83,7 @@ class NougatParser(BaseParser):
     def __init__(self, config: NougatParserConfig) -> None:
         """Initialize the marker parser."""
         import torch
-        from nougat import NougatModel
+        from nougat import NougatModel  # type: ignore
         from nougat.utils.device import move_to_device
 
         self.config = config

--- a/pdfwf/parsers/oreo/oreo.py
+++ b/pdfwf/parsers/oreo/oreo.py
@@ -1,4 +1,5 @@
 """The Oreo parser for extracting text and visual content from PDFs."""
+
 from __future__ import annotations
 
 import sys

--- a/pdfwf/parsers/oreo/tensor_utils.py
+++ b/pdfwf/parsers/oreo/tensor_utils.py
@@ -1,4 +1,5 @@
 """Tensor-based utilities for Oreo."""
+
 from __future__ import annotations
 
 import gc

--- a/pdfwf/parsl.py
+++ b/pdfwf/parsl.py
@@ -1,4 +1,5 @@
 """Utilities to build Parsl configurations."""
+
 from __future__ import annotations
 
 from abc import ABC

--- a/pdfwf/timer.py
+++ b/pdfwf/timer.py
@@ -109,8 +109,14 @@ class Timer:
         self._start_unix = time.time()
         return self
 
-    def stop(self) -> None:
-        """Stop the timer."""
+    def stop(self, flush: bool = False) -> None:
+        """Stop the timer.
+
+        Parameters
+        ----------
+        flush : bool, optional
+            Flush the buffer (usually stdout), by default False
+        """
         self._end = time.perf_counter_ns()
         self._end_unix = time.time()
         self._running = False
@@ -120,7 +126,7 @@ class Timer:
             start_unix=self._start_unix,
             end_unix=self._end_unix,
         )
-        TimeLogger().log(time_stats)
+        TimeLogger().log(time_stats, flush=flush)
 
 
 class TimeLogger:
@@ -153,10 +159,19 @@ class TimeLogger:
 
         return time_stats
 
-    def log(self, ts: TimeStats) -> None:
-        """Log the timer information."""
+    def log(self, ts: TimeStats, flush: bool = False) -> None:
+        """Log the timer information.
+
+        Parameters
+        ----------
+        ts : TimeStats
+            The time statistics object to be logged
+        flush : bool, optional
+            Flush the buffer (usually stdout), by default False
+        """
         print(
             f'[timer] [{" ".join(map(str, ts.tags))}]'
             f' in [{ts.elapsed_s:.2f}] seconds.',
             f' start: [{ts.start_unix:.2f}], end: [{ts.end_unix:.2f}]',
+            flush=flush,
         )

--- a/pdfwf/utils.py
+++ b/pdfwf/utils.py
@@ -1,4 +1,5 @@
 """Utilities for the PDF workflow."""
+
 from __future__ import annotations
 
 import json

--- a/pdfwf/utils.py
+++ b/pdfwf/utils.py
@@ -6,6 +6,7 @@ import json
 import logging
 import sys
 import traceback
+import zipfile
 from pathlib import Path
 from typing import Any
 from typing import Callable
@@ -156,3 +157,21 @@ def batch_data(data: list[T], chunk_size: int) -> list[list[T]]:
     if len(data) > chunk_size * len(batches):
         batches.append(data[len(batches) * chunk_size :])
     return batches
+
+
+def zip_worker(files: list[Path], output_path: Path) -> Path:
+    """Worker function to zip together a group of pdfs.
+
+    Parameters
+    ----------
+    files : list[Path]
+        List of files to zip together
+    output_path : Path
+        Output zip file to create
+    """
+    with zipfile.ZipFile(output_path, 'w') as zipf:
+        for infile in files:
+            # Add each file to the ZIP
+            zipf.write(infile, infile.name)
+
+    return output_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ allow_untyped_defs = true
 
 [tool.ruff]
 # See all rules here: https://beta.ruff.rs/docs/rules
-select = [
+lint.select = [
     # pyflakes
     "F",
     # pycodestyle
@@ -130,14 +130,14 @@ select = [
     "RUF",
 ]
 line-length = 79
-extend-ignore = []
+lint.extend-ignore = []
 target-version = "py38"
-ignore = ["COM812", "ISC001"] # silence warning
+lint.ignore = ["COM812", "ISC001"] # silence warning
 
-[tool.ruff.flake8-pytest-style]
+[tool.ruff.lint.flake8-pytest-style]
 parametrize-values-type = "tuple"
 
-[tool.ruff.flake8-quotes]
+[tool.ruff.lint.flake8-quotes]
 inline-quotes = "single"
 multiline-quotes = "double" # silence warning
 
@@ -145,17 +145,17 @@ multiline-quotes = "double" # silence warning
 indent-style = "space"
 quote-style = "single"
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 force-single-line = true
 known-first-party = ["pdfwf", "test", "testing"]
 order-by-type = false
 required-imports = ["from __future__ import annotations"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "*/__init__.py" = ["F401"]
 "*/*_test.py" = ["D10"]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "numpy"
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pdfwf"
-version = "0.1.5"
+version = "0.1.6"
 authors = [
     {name = "Kyle Hippe", email = "khippe@anl.gov"},
     {name = "Alexander Brace", email = "abrace@anl.gov"},

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -1,2 +1,3 @@
 """Utilities for unit tests."""
+
 from __future__ import annotations

--- a/testing/data.py
+++ b/testing/data.py
@@ -1,4 +1,5 @@
 """Example data for testing."""
+
 from __future__ import annotations
 
 DATA: list[tuple[list[int], int]] = [([1, 2, 3, 4], 10)]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,3 @@
 """pdfwf unit tests."""
+
 from __future__ import annotations


### PR DESCRIPTION
# Description
Adding support for resume from existing output directory for .zip inputs. 
Adding small CLI function to zip PDF's together

Note: The method used for looking for parsed inputs will only work on.zip inputs. This is 
a by product of the way logging is handled for .pdfs (the batches do not log each individual batch being processed in the same way the parsing a zip file logs the root zip file that contains the whole batch being processed). If we need to add support for resuming from a parsing run that uses .pdf files, we need to explicitly log these in a different manner. 


### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
Testing on small zip input on polaris

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [ ] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [X] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [ ] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
