### PR TITLE
Bug fix: Timer parsing blank file 

### DIFF
--- a/pdfwf/timer.py
+++ b/pdfwf/timer.py
@@ -148,6 +148,9 @@ class TimeLogger:
         # Extracted items from all print statements
         for line in lines:
             match = re.findall(regex_pattern, line)
+            # If the line doesn't contain the timer information, skip it
+            if not match:
+                continue
             time_stats.append(
                 TimeStats(
                     tags=match[1].split(),


### PR DESCRIPTION
Bug fix:

If a blank *.stdout file (from parsl) exists, the timers will try and parse it and the regex will return a None object that we try and index into. This checks and continues in the case of a blank file.